### PR TITLE
fix water and lava proof

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,27 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/java
+{
+	"name": "Java",
+	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+	"image": "mcr.microsoft.com/devcontainers/java:1-17-bullseye",
+
+	"features": {
+		"ghcr.io/devcontainers/features/java:1": {
+			"version": "none",
+			"installMaven": "true",
+			"installGradle": "true"
+		}
+	}
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	// "postCreateCommand": "java -version",
+
+	// Configure tool-specific properties.
+	// "customizations": {},
+
+	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "root"
+}

--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ repositories {
 	}
 	maven {
 		name = 'Ladysnake Mods'
-		url = 'https://ladysnake.jfrog.io/artifactory/mods'
+		url = 'https://maven.ladysnake.org/releases'
 	}
 	maven { url "https://maven.shedaniel.me/" }
 }

--- a/src/main/java/net/guavy/gravestones/block/GravestoneBlock.java
+++ b/src/main/java/net/guavy/gravestones/block/GravestoneBlock.java
@@ -8,6 +8,9 @@ import net.guavy.gravestones.config.GravestoneRetrievalType;
 import net.guavy.gravestones.config.GravestonesConfig;
 import net.minecraft.block.*;
 import net.minecraft.block.entity.BlockEntity;
+import net.minecraft.fluid.FluidState;
+import net.minecraft.fluid.Fluids;
+import net.minecraft.fluid.Fluid;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EquipmentSlot;
 import net.minecraft.entity.LivingEntity;
@@ -28,12 +31,13 @@ import net.minecraft.util.shape.VoxelShape;
 import net.minecraft.util.shape.VoxelShapes;
 import net.minecraft.world.BlockView;
 import net.minecraft.world.World;
+import net.minecraft.world.WorldAccess;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
 import java.util.List;
 
-public class GravestoneBlock extends HorizontalFacingBlock implements BlockEntityProvider {
+public class GravestoneBlock extends HorizontalFacingBlock implements FluidFillable, BlockEntityProvider {
     public GravestoneBlock(Settings settings) {
         super(settings);
         setDefaultState(this.stateManager.getDefaultState().with(Properties.HORIZONTAL_FACING, Direction.NORTH));
@@ -69,6 +73,16 @@ public class GravestoneBlock extends HorizontalFacingBlock implements BlockEntit
 
         dropAllGrave(world, pos);
         super.onBreak(world, pos, state, player);
+    }
+
+    @Override
+    public boolean tryFillWithFluid(WorldAccess world, BlockPos pos, BlockState state, FluidState fluidState) {
+        return false;
+    }
+
+    @Override
+    public boolean canFillWithFluid(BlockView world, BlockPos pos, BlockState state, Fluid fluid) {
+        return false;
     }
 
     @Override


### PR DESCRIPTION
Hi,
this pull request include these improvements.

- fix water and lava proof through implements [FluidFillable](https://maven.fabricmc.net/docs/yarn-23w32a+build.6/net/minecraft/block/FluidFillable.html) class and overwrite two method to prevent liquid fill gravestone block.

```java
boolean
canFillWithFluid(@Nullable PlayerEntity player, BlockView world, BlockPos pos, BlockState state, Fluid fluid)

boolean
tryFillWithFluid(WorldAccess world, BlockPos pos, BlockState state, FluidState fluidState)
```

- replace a ladysnake maven repo which is invalid, you can delete it if you want.
- create a devcontainer that allow us to use Github Codespace test it directly.

Thanks for your greate work.